### PR TITLE
[MARS] Add and update go dockerfile version

### DIFF
--- a/devcontainers/robocin-go-base.Dockerfile
+++ b/devcontainers/robocin-go-base.Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/devcontainers/go:1.23
+
+RUN set -x && \
+    apt update && apt upgrade -y && \
+    \
+    apt install libsodium-dev libczmq-dev protobuf-compiler -y && \
+    \
+    : # last line
+
+RUN set -x && \
+    go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28 && \
+    go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2 && \
+    \
+    : # last line


### PR DESCRIPTION
**Problem:** We need go 1.23 or higher to use golang gRPC in MARS gateway
**Solution:** Update go version in docker image