### PR TITLE
[rcpilot] Add pre-commit to container

### DIFF
--- a/one/devco-jazzy-desktop-full.Dockerfile
+++ b/one/devco-jazzy-desktop-full.Dockerfile
@@ -26,5 +26,9 @@ RUN robocin-install \
     ros2-dependencies \
     eigen
 
+RUN pip3 install \
+    pre-commit \
+    --break-system-packages
+
 RUN robocin-user
 USER robocin


### PR DESCRIPTION
This pull request adds a new dependency to the Docker build process by installing the `pre-commit` tool using pip. This will help ensure that code quality checks can be run automatically during development.

Dependency management:

* Added installation of the `pre-commit` package via pip in the `one/devco-jazzy-desktop-full.Dockerfile`, using the `--break-system-packages` flag to allow installation in the system environment.