### PR TITLE
[rcpilot] Add support for multiple platforms in workflow

### DIFF
--- a/.github/workflows/build-and-push-manually.yaml
+++ b/.github/workflows/build-and-push-manually.yaml
@@ -58,6 +58,7 @@ jobs:
           context: ${{ env.dir-name }}
           file: ${{ github.event.inputs.full-name }}
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ secrets.DOCKER_HUB_ID }}/${{ env.file-name }}:${{ env.tag-name }}
             ${{ secrets.DOCKER_HUB_ID }}/${{ env.file-name }}:latest


### PR DESCRIPTION
This pull request makes a minor update to the build workflow configuration by specifying the platforms for Docker image builds.

* Build configuration:
  * [`.github/workflows/build-and-push-manually.yaml`](diffhunk://#diff-628b618b0c64ef63d107843a30fe74595498fdadbea9ab0993ea541b8743254bR61): Added the `platforms` option to the Docker build step to ensure images are built for both `linux/amd64` and `linux/arm64` architectures.