### PR TITLE
[workflow] Add QEMU setup step to build-and-push workflow

### DIFF
--- a/.github/workflows/build-and-push-manually.yaml
+++ b/.github/workflows/build-and-push-manually.yaml
@@ -37,6 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: verify-arguments
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Docker Buildx


### PR DESCRIPTION
This pull request introduces a small but important update to the GitHub Actions workflow for manual builds. The change sets up QEMU before the build steps, which is necessary for enabling multi-platform Docker builds.

* Workflow improvement:
  * Added a step to set up QEMU using `docker/setup-qemu-action@v2` in the `.github/workflows/build-and-push-manually.yaml` workflow.